### PR TITLE
fix: es8316: add missing Mic devices

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*               @RadxaYuntian

--- a/src/alsa/ucm2/conf.d/rockchip-es8316/HiFi.conf
+++ b/src/alsa/ucm2/conf.d/rockchip-es8316/HiFi.conf
@@ -21,3 +21,17 @@ SectionDevice."Headphones" {
 	]
 }
 
+SectionDevice."Mic" {
+	Comment "Internal Microphone"
+
+	EnableSequence [
+		cset "name='Differential Mux' lin2-rin2"
+	]
+
+	Value {
+		CapturePriority 500
+		CapturePCM "hw:${CardId}"
+		CaptureMixerElem "ADC PGA Gain"
+		CaptureMasterElem "ADC"
+	}
+}


### PR DESCRIPTION
* close https://github.com/radxa-pkg/radxa-alsa-config/issues/6

* This config come from https://github.com/alsa-project/alsa-ucm-conf/blob/9e245901aedee9efd5ede249dc8ba3efc747f7bf/ucm2/Rockchip/es8316/HiFi.conf#L29-L42