### PR TITLE
fix(ucm2): correct nonexistent ALSA controls for sunxi-ac101b

### DIFF
--- a/src/alsa/ucm2/conf.d/sunxi-ac101/HiFi.conf
+++ b/src/alsa/ucm2/conf.d/sunxi-ac101/HiFi.conf
@@ -1,0 +1,158 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='OutputL Mixer DACL Switch' off"
+		cset "name='OutputR Mixer DACR Switch' off"
+		cset "name='LINEOUTL Switch' off"
+		cset "name='LINEOUTR Switch' off"
+		cset "name='SPK Switch' off"
+		cset "name='SPK Volume' 31"
+		cset "name='MIC1 Switch' off"
+		cset "name='MIC2 Switch' off"
+		cset "name='InputL Mixer MIC1 Switch' off"
+		cset "name='InputR Mixer MIC2 Switch' off"
+		cset "name='ADCL Gain' 7"
+		cset "name='ADCR Gain' 7"
+		cset "name='MIC1 Gain' 7"
+		cset "name='MIC2 Gain' 7"
+		cset "name='LINEIN Gain' 7"
+		cset "name='HPOUTL Switch' off"
+		cset "name='HPOUTR Switch' off"
+		cset "name='InputL Mixer LINEIN Switch' off"
+		cset "name='LINEINL Switch' off"
+		cset "name='LINEINR Switch' off"
+		cset "name='ADCL Volume' 160"
+		cset "name='ADCR Volume' 160"
+	]
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='OutputL Mixer DACL Switch' on"
+		cset "name='OutputR Mixer DACR Switch' on"
+		cset "name='LINEOUTL Switch' on"
+		cset "name='LINEOUTR Switch' on"
+		cset "name='SPK Switch' on"
+		cset "name='SPK Volume' 16"
+	]
+
+	DisableSequence [
+		cset "name='OutputL Mixer DACL Switch' off"
+		cset "name='OutputR Mixer DACR Switch' off"
+		cset "name='LINEOUTL Switch' off"
+		cset "name='LINEOUTR Switch' off"
+		cset "name='SPK Switch' off"
+		cset "name='SPK Volume' 31"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackChannels "2"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Main Mic"
+
+	ConflictingDevice [
+		"Headset Mic"
+	]
+
+	EnableSequence [
+		cset "name='MIC1 Switch' on"
+		cset "name='MIC2 Switch' on"
+		cset "name='InputL Mixer MIC1 Switch' on"
+		cset "name='InputR Mixer MIC2 Switch' on"
+		cset "name='ADCL Gain' 3"
+		cset "name='ADCR Gain' 3"
+		cset "name='MIC1 Gain' 3"
+		cset "name='MIC2 Gain' 3"
+	]
+
+	DisableSequence [
+		cset "name='MIC1 Switch' off"
+		cset "name='MIC2 Switch' off"
+		cset "name='InputL Mixer MIC1 Switch' off"
+		cset "name='InputR Mixer MIC2 Switch' off"
+		cset "name='ADCL Gain' 7"
+		cset "name='ADCR Gain' 7"
+		cset "name='MIC1 Gain' 7"
+		cset "name='MIC2 Gain' 7"
+	]
+
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId},0"
+		CaptureChannels "2"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cset "name='DACL Volume' 194"
+		cset "name='DACR Volume' 194"
+		cset "name='HPOUT Volume' 54"
+		cset "name='OutputR Mixer DACR Switch' on"
+		cset "name='OutputL Mixer DACL Switch' on"
+		cset "name='HPOUTL Switch' on"
+		cset "name='HPOUTR Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='OutputR Mixer DACR Switch' off"
+		cset "name='OutputL Mixer DACL Switch' off"
+		cset "name='HPOUTL Switch' off"
+		cset "name='HPOUTR Switch' off"
+	]
+
+	Value {
+		PlaybackVolume "HPOUT Volume"
+		PlaybackPriority 200
+		PlaybackChannels "2"
+		PlaybackPCM "hw:${CardId},0"
+		JackControl "HP Jack"
+	}
+}
+
+SectionDevice."Headset Mic" {
+	Comment "Headset Mic"
+
+	ConflictingDevice [
+		"Mic"
+	]
+
+	EnableSequence [
+		cset "name='InputL Mixer LINEIN Switch' on"
+		cset "name='LINEINL Switch' on"
+		cset "name='LINEINR Switch' on"
+		cset "name='ADCL Volume' 172"
+		cset "name='ADCR Volume' 172"
+	]
+
+	DisableSequence [
+		cset "name='InputL Mixer LINEIN Switch' off"
+		cset "name='LINEINL Switch' off"
+		cset "name='LINEINR Switch' off"
+		cset "name='ADCL Volume' 160"
+		cset "name='ADCR Volume' 160"
+	]
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},0"
+		CaptureChannels "1"
+		JackControl "HS MIC Jack"
+	}
+}

--- a/src/alsa/ucm2/conf.d/sunxi-ac101/sunxi-ac101.conf
+++ b/src/alsa/ucm2/conf.d/sunxi-ac101/sunxi-ac101.conf
@@ -1,0 +1,6 @@
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "default"
+}

--- a/src/alsa/ucm2/conf.d/sunxi-ac101b/HiFi.conf
+++ b/src/alsa/ucm2/conf.d/sunxi-ac101b/HiFi.conf
@@ -1,96 +1,78 @@
 SectionVerb {
-	EnableSequence [
-		cset "name='DACL Volume' 137"
-		cset "name='DACR Volume' 137"
-		cset "name='DAC Gain' 0"
-		cset "name='HPOUT Gain' 3"
-		cset "name='ADC2 Volume' 219"
-		cset "name='ADC2 Gain' 14"
-		cset "name='ADC1 Volume' 0"
-		cset "name='ADC1 Gain' 0"
-		cset "name='ADC2 PAG MUX' 1"
-		cset "name='ADC2 MUX' 3"
-		cset "name='ADC1 MUX' 0"
-		cset "name='RX1 MUX' 3"
-		cset "name='RX2 MUX' 2"
-		cset "name='RX3 MUX' 3"
-		cset "name='SPK Switch' off"
-		cset "name='HPOUT Switch' on"
-		cset "name='LINEOUTL Switch' off"
-		cset "name='LINEOUTR Switch' off"
-		cset "name='MIC1 Switch' off"
-		cset "name='MIC2 Switch' off"
-		cset "name='MIC3 Switch' off"
-		cset "name='MIC4 Switch' on"
-	]
+        EnableSequence [
+                cset "name='DACL Volume' 137"
+                cset "name='DACR Volume' 137"
+                cset "name='DAC Gain' 0"
+                cset "name='HPOUT Gain' 3"
+                cset "name='HPOUT Switch' on"
+                cset "name='SPK Switch' off"
+                cset "name='LINEOUTL Switch' off"
+                cset "name='LINEOUTR Switch' off"
+                cset "name='MIC1 Switch' off"
+                cset "name='MIC2 Switch' off"
+                cset "name='MIC3 Switch' off"
+                cset "name='MIC4 Switch' on"
+                cset "name='ADC2 Input Src Mux' MIC4"
+                cset "name='ADC2 Data Select Mux' ADC2_Input"
+                cset "name='ADC2 Gain' 14"
+                cset "name='ADC2 Volume' 219"
+                cset "name='AIF TX2 Mux' ADC2_Data"
+                cset "name='ADC1 Volume' 0"
+                cset "name='ADC1 Gain' 0"
+        ]
 
-	DisableSequence [
-		cset "name='SPK Switch' off"
-		cset "name='HPOUT Switch' off"
-		cset "name='MIC4 Switch' off"
-	]
-}
-
-SectionDevice."Speaker" {
-	Comment "Internal Speaker"
-
-	EnableSequence [
-		cset "name='SPK Switch' on"
-	]
-
-	DisableSequence [
-		cset "name='SPK Switch' off"
-	]
-
-	Value {
-		PlaybackPriority 100
-		PlaybackPCM "hw:${CardId}"
-	}
+        DisableSequence [
+                cset "name='SPK Switch' off"
+                cset "name='HPOUT Switch' off"
+                cset "name='MIC4 Switch' off"
+        ]
 }
 
 SectionDevice."Headphones" {
-	Comment "Headphones"
+        Comment "Headphones"
 
-	EnableSequence [
-		cset "name='SPK Switch' off"
-		cset "name='HPOUT Switch' on"
-		cset "name='HPOUT Gain' 3"
-		cset "name='DACL Volume' 137"
-		cset "name='DACR Volume' 137"
-	]
+        EnableSequence [
+                cset "name='SPK Switch' off"
+                cset "name='HPOUT Switch' on"
+                cset "name='HPOUT Gain' 3"
+                cset "name='DACL Volume' 137"
+                cset "name='DACR Volume' 137"
+        ]
 
-	DisableSequence [
-		cset "name='HPOUT Switch' off"
-		cset "name='SPK Switch' on"
-	]
+        DisableSequence [
+                cset "name='HPOUT Switch' off"
+                cset "name='SPK Switch' off"
+        ]
 
-	Value {
-		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId}"
-		JackControl "HP Jack"
-	}
+        Value {
+                PlaybackVolume "HPOUT Gain"
+                PlaybackPriority 200
+                PlaybackChannels "2"
+                PlaybackPCM "hw:${CardId},0"
+                JackControl "HP Jack"
+        }
 }
 
-SectionDevice."Mic" {
-	Comment "Internal Microphone"
+SectionDevice."Headset Mic" {
+        Comment "Headset Mic"
 
-	EnableSequence [
-		cset "name='MIC4 Switch' on"
-		cset "name='ADC2 PAG MUX' 1"
-		cset "name='ADC2 MUX' 3"
-		cset "name='RX2 MUX' 2"
-		cset "name='RX3 MUX' 3"
-		cset "name='ADC2 Gain' 14"
-		cset "name='ADC2 Volume' 219"
-	]
+        EnableSequence [
+                cset "name='MIC4 Switch' on"
+                cset "name='ADC2 Input Src Mux' MIC4"
+                cset "name='ADC2 Data Select Mux' ADC2_Input"
+                cset "name='ADC2 Gain' 14"
+                cset "name='ADC2 Volume' 219"
+                cset "name='AIF TX2 Mux' ADC2_Data"
+        ]
 
-	DisableSequence [
-		cset "name='MIC4 Switch' off"
-		cset "name='ADC2 Gain' 0"
-	]
+        DisableSequence [
+                cset "name='MIC4 Switch' off"
+                cset "name='ADC2 Gain' 0"
+        ]
 
-	Value {
-		CapturePriority 100
-		CapturePCM "hw:${CardId}"
-	}
+        Value {
+                CapturePriority 200
+                CapturePCM "hw:${CardId},0"
+                CaptureChannels "1"
+        }
 }

--- a/src/alsa/ucm2/sunxi-ac101
+++ b/src/alsa/ucm2/sunxi-ac101
@@ -1,0 +1,1 @@
+conf.d/sunxi-ac101

--- a/src/alsa/ucm2/sunxi-ac101/HiFi.conf
+++ b/src/alsa/ucm2/sunxi-ac101/HiFi.conf
@@ -1,1 +1,0 @@
-../allwinner-ac101/HiFi.conf

--- a/src/alsa/ucm2/sunxi-ac101/sunxi-ac101.conf
+++ b/src/alsa/ucm2/sunxi-ac101/sunxi-ac101.conf
@@ -1,1 +1,0 @@
-../allwinner-ac101/allwinner-ac101.conf


### PR DESCRIPTION
Replace controls that don't exist on this hardware with the proper ones, and unify indentation.